### PR TITLE
Ensure sans-serif fonts in figures

### DIFF
--- a/app.R
+++ b/app.R
@@ -42,6 +42,11 @@ enableBookmarking(store = "url")
 # Harmonize UI and plot fonts across environments
 thematic::thematic_shiny(font = "Arial")
 
+# Ensure figures default to a sans-serif font as well
+theme_set(theme_minimal(base_family = "Arial"))
+update_geom_defaults("text", list(family = "Arial"))
+update_geom_defaults("label", list(family = "Arial"))
+
 # Load data
 
 #files <- list.files(path="istraxes", pattern = "parquet$", full.names = TRUE)


### PR DESCRIPTION
## Summary
- set ggplot defaults to use Arial for figure text
- update text and label geom defaults to prefer sans-serif fonts alongside existing thematic settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940252893d88323ade118870fe7c621)