### PR TITLE
Ensure girafe plots use app font

### DIFF
--- a/app.R
+++ b/app.R
@@ -317,6 +317,10 @@ ui <- function(request){fluidPage(
         color: #34495E;
         margin-bottom: 20px;
       }
+      /* Ensure ggiraph/plot text matches the app's sans-serif font */
+      .girafe_container svg text, .girafe_container svg tspan {
+        font-family: 'Arial', sans-serif !important;
+      }
     "))
   ),
   


### PR DESCRIPTION
## Summary
- add CSS override so ggiraph SVG text uses the app’s Arial/sans-serif font

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694049bcfecc83238ad2cf7e2587add2)